### PR TITLE
Send midi program change messages

### DIFF
--- a/src/apps/sequencer/engine/Engine.cpp
+++ b/src/apps/sequencer/engine/Engine.cpp
@@ -486,7 +486,7 @@ void Engine::updatePlayState(bool ticked) {
             }
 
             if (allPatternsEqual) {
-                _midiOutputEngine.sendProgramChange(1, playState.trackState(0).pattern());
+                _midiOutputEngine.sendProgramChange(0, playState.trackState(0).pattern());
             }
         }
     }

--- a/src/apps/sequencer/engine/Engine.cpp
+++ b/src/apps/sequencer/engine/Engine.cpp
@@ -469,7 +469,6 @@ void Engine::updatePlayState(bool ticked) {
 
             // handle pattern requests
             if (trackState.hasRequests(patternRequests)) {
-                fprintf(stderr, "HAS PATTERN REQUEST\n");
                 trackState.setPattern(trackState.requestedPattern());
                 changedPatterns = true;
             }
@@ -583,7 +582,6 @@ void Engine::updatePlayState(bool ticked) {
     }
 
     if (hasRequests | handleSongAdvance) {
-//        fprintf(stderr, "CHANGING PATTERN\n");
         for (int trackIndex = 0; trackIndex < CONFIG_TRACK_COUNT; ++trackIndex) {
             _trackEngines[trackIndex]->changePattern();
         }

--- a/src/apps/sequencer/engine/Engine.cpp
+++ b/src/apps/sequencer/engine/Engine.cpp
@@ -433,6 +433,20 @@ void Engine::reset() {
     _midiOutputEngine.reset();
 }
 
+bool allPatternsEqual(PlayState playState) {
+    auto firstTrackState = playState.trackState(0);
+
+    for (int trackIndex = 0; trackIndex < CONFIG_TRACK_COUNT; ++trackIndex) {
+        auto trackState = playState.trackState(trackIndex);
+
+        if (trackState.pattern() != firstTrackState.pattern()
+            || trackState.requestedPattern() != firstTrackState.requestedPattern()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void Engine::updatePlayState(bool ticked) {
     auto &playState = _project.playState();
     auto &songState = playState.songState();
@@ -444,7 +458,16 @@ void Engine::updatePlayState(bool ticked) {
     bool hasRequests = hasImmediateRequests || hasSyncedRequests || handleLatchedRequests;
 
     bool handleSyncedRequests = _tick % syncDivisor() == 0;
+    bool preHandleSyncedRequests = (_tick + 192) % syncDivisor() == 0;
     bool handleSongAdvance = ticked && _tick > 0 && _tick % measureDivisor() == 0;
+
+    // send initial program change if we haven't sent it already
+    // means that when the sequencer initially starts, it will sync connected devices to the same pattern
+    // only works when all patterns are equal
+    if (_project.midiPgmChangeEnabled() && !_midiHasSentInitialPgmChange && allPatternsEqual(playState)) {
+        _midiOutputEngine.sendProgramChange(0, playState.trackState(0).pattern());
+        _midiHasSentInitialPgmChange = true;
+    }
 
     // handle mute & pattern requests
 
@@ -477,17 +500,12 @@ void Engine::updatePlayState(bool ticked) {
             trackState.clearRequests(muteRequests | patternRequests);
         }
 
-        if (changedPatterns && _project.midiPgmChangeEnabled()) {
-            bool allPatternsEqual = true;
-            for (int trackIndex = 0; trackIndex < CONFIG_TRACK_COUNT; ++trackIndex) {
-                if (playState.trackState(trackIndex).pattern() != playState.trackState(0).pattern()) {
-                    allPatternsEqual = false;
-                }
-            }
+        bool shouldSendPgmChange = !preSendMidiPgmChange && changedPatterns;
+        bool shouldPreSendPgmChange = preSendMidiPgmChange && ((changedPatterns && !playState.hasSyncedRequests())
+                || (preHandleSyncedRequests && playState.hasSyncedRequests()));
 
-            if (allPatternsEqual) {
-                _midiOutputEngine.sendProgramChange(0, playState.trackState(0).pattern());
-            }
+        if (_project.midiPgmChangeEnabled() && (shouldSendPgmChange || shouldPreSendPgmChange) && allPatternsEqual(playState)) {
+            _midiOutputEngine.sendProgramChange(0, playState.trackState(0).requestedPattern());
         }
     }
 

--- a/src/apps/sequencer/engine/Engine.cpp
+++ b/src/apps/sequencer/engine/Engine.cpp
@@ -500,9 +500,9 @@ void Engine::updatePlayState(bool ticked) {
             trackState.clearRequests(muteRequests | patternRequests);
         }
 
-        bool shouldSendPgmChange = !preSendMidiPgmChange && changedPatterns;
-        bool shouldPreSendPgmChange = preSendMidiPgmChange && ((changedPatterns && !playState.hasSyncedRequests())
-                || (preHandleSyncedRequests && playState.hasSyncedRequests()));
+        bool shouldSendPgmChange = !_preSendMidiPgmChange && changedPatterns;
+        bool shouldPreSendPgmChange = _preSendMidiPgmChange && ((changedPatterns && !playState.hasSyncedRequests())
+                                                                || (preHandleSyncedRequests && playState.hasSyncedRequests()));
 
         if (_project.midiPgmChangeEnabled() && (shouldSendPgmChange || shouldPreSendPgmChange) && allPatternsEqual(playState)) {
             _midiOutputEngine.sendProgramChange(0, playState.trackState(0).requestedPattern());

--- a/src/apps/sequencer/engine/Engine.h
+++ b/src/apps/sequencer/engine/Engine.h
@@ -242,6 +242,10 @@ private:
         int8_t lastTrack = -1;
     } _midiMonitoring;
 
+    // TODO Could be a setting if needed
+    static const bool preSendMidiPgmChange = true;
+    bool _midiHasSentInitialPgmChange = false;
+
     // gate output overrides
     bool _gateOutputOverride = false;
     uint8_t _gateOutputOverrideValue = 0;

--- a/src/apps/sequencer/engine/Engine.h
+++ b/src/apps/sequencer/engine/Engine.h
@@ -243,7 +243,7 @@ private:
     } _midiMonitoring;
 
     // TODO Could be a setting if needed
-    static const bool preSendMidiPgmChange = true;
+    static const bool _preSendMidiPgmChange = true;
     bool _midiHasSentInitialPgmChange = false;
 
     // gate output overrides

--- a/src/apps/sequencer/engine/MidiOutputEngine.cpp
+++ b/src/apps/sequencer/engine/MidiOutputEngine.cpp
@@ -150,7 +150,7 @@ void MidiOutputEngine::sendCv(int trackIndex, float cv) {
 
 void MidiOutputEngine::sendProgramChange(int channel, int programNumber) {
     auto pgmChangeMessage = MidiMessage::makeProgramChange(channel, programNumber);
-
+    fprintf(stderr, "SENDING PROGRAM CHANGE\n");
     sendMidi(MidiPort::Midi, pgmChangeMessage);
     sendMidi(MidiPort::UsbMidi, pgmChangeMessage);
 }

--- a/src/apps/sequencer/engine/MidiOutputEngine.cpp
+++ b/src/apps/sequencer/engine/MidiOutputEngine.cpp
@@ -148,6 +148,13 @@ void MidiOutputEngine::sendCv(int trackIndex, float cv) {
     }
 }
 
+void MidiOutputEngine::sendProgramChange(int channel, int programNumber) {
+    auto pgmChangeMessage = MidiMessage::makeProgramChange(channel, programNumber);
+
+    sendMidi(MidiPort::Midi, pgmChangeMessage);
+    sendMidi(MidiPort::UsbMidi, pgmChangeMessage);
+}
+
 void MidiOutputEngine::resetOutput(int outputIndex) {
     auto &outputState = _outputStates[outputIndex];
 

--- a/src/apps/sequencer/engine/MidiOutputEngine.cpp
+++ b/src/apps/sequencer/engine/MidiOutputEngine.cpp
@@ -150,7 +150,7 @@ void MidiOutputEngine::sendCv(int trackIndex, float cv) {
 
 void MidiOutputEngine::sendProgramChange(int channel, int programNumber) {
     auto pgmChangeMessage = MidiMessage::makeProgramChange(channel, programNumber);
-    fprintf(stderr, "SENDING PROGRAM CHANGE\n");
+
     sendMidi(MidiPort::Midi, pgmChangeMessage);
     sendMidi(MidiPort::UsbMidi, pgmChangeMessage);
 }

--- a/src/apps/sequencer/engine/MidiOutputEngine.h
+++ b/src/apps/sequencer/engine/MidiOutputEngine.h
@@ -24,6 +24,7 @@ public:
     void sendGate(int trackIndex, bool gate);
     void sendSlide(int trackIndex, bool slide);
     void sendCv(int trackIndex, float cv);
+    void sendProgramChange(int channel, int programNumber);
 
 private:
     struct OutputState {

--- a/src/apps/sequencer/engine/NoteTrackEngine.cpp
+++ b/src/apps/sequencer/engine/NoteTrackEngine.cpp
@@ -263,7 +263,6 @@ void NoteTrackEngine::update(float dt) {
 }
 
 void NoteTrackEngine::changePattern() {
-//    fprintf(stderr, "TRACKSTATE PATTERN: %d\n", _trackState.pattern());
     _sequence = &_noteTrack.sequence(pattern());
     _fillSequence = &_noteTrack.sequence(std::min(pattern() + 1, CONFIG_PATTERN_COUNT - 1));
 }

--- a/src/apps/sequencer/engine/NoteTrackEngine.cpp
+++ b/src/apps/sequencer/engine/NoteTrackEngine.cpp
@@ -263,6 +263,7 @@ void NoteTrackEngine::update(float dt) {
 }
 
 void NoteTrackEngine::changePattern() {
+//    fprintf(stderr, "TRACKSTATE PATTERN: %d\n", _trackState.pattern());
     _sequence = &_noteTrack.sequence(pattern());
     _fillSequence = &_noteTrack.sequence(std::min(pattern() + 1, CONFIG_PATTERN_COUNT - 1));
 }

--- a/src/apps/sequencer/model/Project.cpp
+++ b/src/apps/sequencer/model/Project.cpp
@@ -106,6 +106,7 @@ void Project::write(VersionedSerializedWriter &writer) const {
     writer.write(_swing.base);
     _timeSignature.write(writer);
     writer.write(_syncMeasure);
+    writer.write(_alwaysSync);
     writer.write(_scale);
     writer.write(_rootNote);
     writer.write(_monitorMode);
@@ -147,6 +148,9 @@ bool Project::read(VersionedSerializedReader &reader) {
         _timeSignature.read(reader);
     }
     reader.read(_syncMeasure);
+    if (reader.dataVersion() >= ProjectVersion::Version32) {
+        reader.read(_alwaysSync);
+    }
     reader.read(_scale);
     reader.read(_rootNote);
     reader.read(_monitorMode, ProjectVersion::Version30);

--- a/src/apps/sequencer/model/Project.cpp
+++ b/src/apps/sequencer/model/Project.cpp
@@ -38,6 +38,7 @@ void Project::clear() {
     setMonitorMode(Types::MonitorMode::Always);
     setRecordMode(Types::RecordMode::Overdub);
     setMidiInputMode(Types::MidiInputMode::All);
+    setMidiPgmChangeEnabled(false);
     setCvGateInput(Types::CvGateInput::Off);
     setCurveCvInput(Types::CurveCvInput::Off);
 
@@ -110,6 +111,7 @@ void Project::write(VersionedSerializedWriter &writer) const {
     writer.write(_monitorMode);
     writer.write(_recordMode);
     writer.write(_midiInputMode);
+    writer.write(_midiPgmChange);
     _midiInputSource.write(writer);
     writer.write(_cvGateInput);
     writer.write(_curveCvInput);
@@ -152,6 +154,9 @@ bool Project::read(VersionedSerializedReader &reader) {
     if (reader.dataVersion() >= ProjectVersion::Version29) {
         reader.read(_midiInputMode);
         _midiInputSource.read(reader);
+    }
+    if (reader.dataVersion() >= ProjectVersion::Version32) {
+        reader.read(_midiPgmChange);
     }
     reader.read(_cvGateInput, ProjectVersion::Version6);
     reader.read(_curveCvInput, ProjectVersion::Version11);

--- a/src/apps/sequencer/model/Project.cpp
+++ b/src/apps/sequencer/model/Project.cpp
@@ -33,6 +33,7 @@ void Project::clear() {
     setSwing(50);
     setTimeSignature(TimeSignature());
     setSyncMeasure(1);
+    setAlwaysSync(false);
     setScale(0);
     setRootNote(0);
     setMonitorMode(Types::MonitorMode::Always);

--- a/src/apps/sequencer/model/Project.cpp
+++ b/src/apps/sequencer/model/Project.cpp
@@ -33,7 +33,7 @@ void Project::clear() {
     setSwing(50);
     setTimeSignature(TimeSignature());
     setSyncMeasure(1);
-    setAlwaysSync(false);
+    setAlwaysSyncPatterns(false);
     setScale(0);
     setRootNote(0);
     setMonitorMode(Types::MonitorMode::Always);
@@ -107,7 +107,7 @@ void Project::write(VersionedSerializedWriter &writer) const {
     writer.write(_swing.base);
     _timeSignature.write(writer);
     writer.write(_syncMeasure);
-    writer.write(_alwaysSync);
+    writer.write(_alwaysSyncPatterns);
     writer.write(_scale);
     writer.write(_rootNote);
     writer.write(_monitorMode);
@@ -150,7 +150,7 @@ bool Project::read(VersionedSerializedReader &reader) {
     }
     reader.read(_syncMeasure);
     if (reader.dataVersion() >= ProjectVersion::Version32) {
-        reader.read(_alwaysSync);
+        reader.read(_alwaysSyncPatterns);
     }
     reader.read(_scale);
     reader.read(_rootNote);

--- a/src/apps/sequencer/model/Project.h
+++ b/src/apps/sequencer/model/Project.h
@@ -124,6 +124,22 @@ public:
         str("%d %s", syncMeasure(), syncMeasure() > 1 ? "bars" : "bar");
     }
 
+    // always sync
+
+    bool alwaysSync() const { return _alwaysSync; }
+    void setAlwaysSync(bool alwaysSync) {
+        _alwaysSync = alwaysSync;
+    }
+
+    void editAlwaysSync(int value, bool shift) {
+        _alwaysSync = value == 1;
+    }
+
+    void printAlwaysSync(StringBuilder &str) const {
+        if (_alwaysSync) str("On");
+        else str("Off");
+    }
+
     // scale
 
     int scale() const { return _scale; }
@@ -445,6 +461,7 @@ private:
     Routable<uint8_t> _swing;
     TimeSignature _timeSignature;
     uint8_t _syncMeasure;
+    bool _alwaysSync;
     uint8_t _scale;
     uint8_t _rootNote;
     Types::RecordMode _recordMode;

--- a/src/apps/sequencer/model/Project.h
+++ b/src/apps/sequencer/model/Project.h
@@ -136,8 +136,8 @@ public:
     }
 
     void printAlwaysSync(StringBuilder &str) const {
-        if (_alwaysSync) str("On");
-        else str("Off");
+        if (_alwaysSync) str("Always");
+        else str("Default");
     }
 
     // scale

--- a/src/apps/sequencer/model/Project.h
+++ b/src/apps/sequencer/model/Project.h
@@ -219,6 +219,23 @@ public:
     const MidiSourceConfig &midiInputSource() const { return _midiInputSource; }
           MidiSourceConfig &midiInputSource()       { return _midiInputSource; }
 
+    // midiPgmChange
+
+    void editMidiPgmChange(int value, bool shift) {
+        _midiPgmChange = value == 1;
+    }
+
+    void printMidiPgmChange(StringBuilder &str) const {
+        if (_midiPgmChange) str("On");
+        else str("Off");
+    }
+
+    void setMidiPgmChangeEnabled(bool enabled) {
+        _midiPgmChange = enabled;
+    }
+
+    bool midiPgmChangeEnabled() const { return _midiPgmChange; }
+
     // cvGateInput
 
     Types::CvGateInput cvGateInput() const { return _cvGateInput; }
@@ -434,6 +451,7 @@ private:
     Types::MonitorMode _monitorMode;
     Types::MidiInputMode _midiInputMode;
     MidiSourceConfig _midiInputSource;
+    bool _midiPgmChange;
     Types::CvGateInput _cvGateInput;
     Types::CurveCvInput _curveCvInput;
 

--- a/src/apps/sequencer/model/Project.h
+++ b/src/apps/sequencer/model/Project.h
@@ -126,17 +126,17 @@ public:
 
     // always sync
 
-    bool alwaysSync() const { return _alwaysSync; }
-    void setAlwaysSync(bool alwaysSync) {
-        _alwaysSync = alwaysSync;
+    bool alwaysSyncPatterns() const { return _alwaysSyncPatterns; }
+    void setAlwaysSyncPatterns(bool alwaysSync) {
+        _alwaysSyncPatterns = alwaysSync;
     }
 
-    void editAlwaysSync(int value, bool shift) {
-        _alwaysSync = value == 1;
+    void editAlwaysSyncPatterns(int value, bool shift) {
+        _alwaysSyncPatterns = value == 1;
     }
 
-    void printAlwaysSync(StringBuilder &str) const {
-        if (_alwaysSync) str("Always");
+    void printAlwaysSyncPatterns(StringBuilder &str) const {
+        if (_alwaysSyncPatterns) str("Always");
         else str("Default");
     }
 
@@ -461,7 +461,7 @@ private:
     Routable<uint8_t> _swing;
     TimeSignature _timeSignature;
     uint8_t _syncMeasure;
-    bool _alwaysSync;
+    bool _alwaysSyncPatterns;
     uint8_t _scale;
     uint8_t _rootNote;
     Types::RecordMode _recordMode;

--- a/src/apps/sequencer/model/ProjectVersion.h
+++ b/src/apps/sequencer/model/ProjectVersion.h
@@ -90,6 +90,9 @@ enum ProjectVersion {
     // changed MidiCvTrack::VoiceConfig to 8-bit value
     Version31 = 31,
 
+    // added Project::midiPgmChange
+    Version32 = 32,
+
     // automatically derive latest version
     Last,
     Latest = Last - 1,

--- a/src/apps/sequencer/model/ProjectVersion.h
+++ b/src/apps/sequencer/model/ProjectVersion.h
@@ -90,7 +90,7 @@ enum ProjectVersion {
     // changed MidiCvTrack::VoiceConfig to 8-bit value
     Version31 = 31,
 
-    // added Project::midiPgmChange
+    // added Project::midiPgmChange and Project::alwaysSync
     Version32 = 32,
 
     // automatically derive latest version

--- a/src/apps/sequencer/ui/model/ProjectListModel.h
+++ b/src/apps/sequencer/ui/model/ProjectListModel.h
@@ -107,7 +107,7 @@ private:
             _project.printSyncMeasure(str);
             break;
         case AlwaysSync:
-            _project.printAlwaysSync(str);
+            _project.printAlwaysSyncPatterns(str);
             break;
         case Scale:
             _project.printScale(str);
@@ -155,7 +155,7 @@ private:
             _project.editSyncMeasure(value, shift);
             break;
         case AlwaysSync:
-            _project.editAlwaysSync(value, shift);
+            _project.editAlwaysSyncPatterns(value, shift);
             break;
         case Scale:
             _project.editScale(value, shift);

--- a/src/apps/sequencer/ui/model/ProjectListModel.h
+++ b/src/apps/sequencer/ui/model/ProjectListModel.h
@@ -71,7 +71,7 @@ private:
         case Swing:             return "Swing";
         case TimeSignature:     return "Time Signature";
         case SyncMeasure:       return "Sync Measure";
-        case AlwaysSync:        return "Always Sync";
+        case AlwaysSync:        return "Sync Patterns";
         case Scale:             return "Scale";
         case RootNote:          return "Root Note";
         case MonitorMode:       return "Monitor Mode";

--- a/src/apps/sequencer/ui/model/ProjectListModel.h
+++ b/src/apps/sequencer/ui/model/ProjectListModel.h
@@ -57,6 +57,7 @@ private:
         MonitorMode,
         RecordMode,
         MidiInput,
+        MidiPgmChange,
         CvGateInput,
         CurveCvInput,
         Last
@@ -74,6 +75,7 @@ private:
         case MonitorMode:       return "Monitor Mode";
         case RecordMode:        return "Record Mode";
         case MidiInput:         return "MIDI Input";
+        case MidiPgmChange:     return "MIDI Pgm Chng";
         case CvGateInput:       return "CV/Gate Input";
         case CurveCvInput:      return "Curve CV Input";
         case Last:              break;
@@ -117,6 +119,9 @@ private:
         case MidiInput:
             _project.printMidiInput(str);
             break;
+        case MidiPgmChange:
+            _project.printMidiPgmChange(str);
+            break;
         case CvGateInput:
             _project.printCvGateInput(str);
             break;
@@ -158,6 +163,9 @@ private:
             break;
         case MidiInput:
             _project.editMidiInput(value, shift);
+            break;
+        case MidiPgmChange:
+            _project.editMidiPgmChange(value, shift);
             break;
         case CvGateInput:
             _project.editCvGateInput(value, shift);

--- a/src/apps/sequencer/ui/model/ProjectListModel.h
+++ b/src/apps/sequencer/ui/model/ProjectListModel.h
@@ -52,6 +52,7 @@ private:
         Swing,
         TimeSignature,
         SyncMeasure,
+        AlwaysSync,
         Scale,
         RootNote,
         MonitorMode,
@@ -70,6 +71,7 @@ private:
         case Swing:             return "Swing";
         case TimeSignature:     return "Time Signature";
         case SyncMeasure:       return "Sync Measure";
+        case AlwaysSync:        return "Always Sync";
         case Scale:             return "Scale";
         case RootNote:          return "Root Note";
         case MonitorMode:       return "Monitor Mode";
@@ -103,6 +105,9 @@ private:
             break;
         case SyncMeasure:
             _project.printSyncMeasure(str);
+            break;
+        case AlwaysSync:
+            _project.printAlwaysSync(str);
             break;
         case Scale:
             _project.printScale(str);
@@ -148,6 +153,9 @@ private:
             break;
         case SyncMeasure:
             _project.editSyncMeasure(value, shift);
+            break;
+        case AlwaysSync:
+            _project.editAlwaysSync(value, shift);
             break;
         case Scale:
             _project.editScale(value, shift);

--- a/src/apps/sequencer/ui/pages/PatternPage.cpp
+++ b/src/apps/sequencer/ui/pages/PatternPage.cpp
@@ -268,7 +268,7 @@ void PatternPage::keyPress(KeyPressEvent &event) {
             // use synced when SYNC is pressed or project set to always sync
             PlayState::ExecuteType executeType;
             if (_latching) executeType = PlayState::Latched;
-            else if (_syncing || _project.alwaysSync()) executeType = PlayState::Synced;
+            else if (_syncing || _project.alwaysSyncPatterns()) executeType = PlayState::Synced;
             else executeType = PlayState::Immediate;
 
             bool globalChange = true;

--- a/src/apps/sequencer/ui/pages/PatternPage.cpp
+++ b/src/apps/sequencer/ui/pages/PatternPage.cpp
@@ -265,8 +265,11 @@ void PatternPage::keyPress(KeyPressEvent &event) {
 
             // use immediate by default
             // use latched when LATCH is pressed
-            // use synced when SYNC is pressed
-            PlayState::ExecuteType executeType = _latching ? PlayState::Latched : (_syncing ? PlayState::Synced : PlayState::Immediate);
+            // use synced when SYNC is pressed or project set to always sync
+            PlayState::ExecuteType executeType;
+            if (_latching) executeType = PlayState::Latched;
+            else if (_syncing || _project.alwaysSync()) executeType = PlayState::Synced;
+            else executeType = PlayState::Immediate;
 
             bool globalChange = true;
             for (int trackIndex = 0; trackIndex < CONFIG_TRACK_COUNT; ++trackIndex) {


### PR DESCRIPTION
Implements midi program change messages

- Sends a midi program change when on pattern change
    - Sends pattern change when all track patterns match (eg. all tracks = pattern 0, increment track 1 to pattern 1, will not trigger a pgm change message. all tracks = pattern 1 apart from track 1, when track 1 changes to pattern 1, then a pgm change message is sent. if all patterns are changed together to the same number, a pgm change message is sent)
- By default, program change messages are sent 1 beat before the program change happens. This fixes issues with certain hardware that needs some time to switch patterns (eg. Analog Rytm) 
- Adds a project setting to enable program change messages 

TODO

- [x] ~~Implement program change receive~~ separate issue: https://github.com/jackpf/performer/issues/12
- [x] ~~Add presend program change events option~~ (currently hardcoded)
- [x] Add option to set pattern change to synced by default